### PR TITLE
specify attributes to a module via render() annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Existing templating systems do support things like logic and reusable modules - 
 ```py
 import html
 print (
-    html.head().appendChild(
-        html.body().appendChild(
+    html.head().append_children(
+        html.body().append_children(
                 html.text("Hello World!"))))
 ```
 
@@ -149,7 +149,7 @@ UI Modules are especially useful for creating re-usable building blocks in your 
 
 Creating UI modules in Pyxl simply means creating a class that inherits from [`x_element`](https://github.com/dropboxe/pyxl/blob/master/pyxl/pyxl/element.py) and implements the `render()` method. Modules must be prefixed with `x_`. This is an arbitrary requirement, but is useful in separating out pyxl modules from other things.
 
-Arguments to a UI module are passed as attributes to the UI module tag. Attribute values for these tags need not evaluate to samething that can be cast to unicode, ONLY if the attribute value is a single python expression i.e. the only thing inside the quotes is a {} wrapped python expression. This allows one to pass in any type to a UI module. To demonstrate, a useful UI module is a user badge, which displays a user profile picture with the user's name and some arbitrary content to the right of it:
+Arguments to a UI module are passed as attributes to the UI module tag. Attribute values for these tags need not evaluate to something that can be cast to unicode, ONLY if the attribute value is a single python expression i.e. the only thing inside the quotes is a {} wrapped python expression. This allows one to pass in any type to a UI module. To demonstrate, a useful UI module is a user badge, which displays a user profile picture with the user's name and some arbitrary content to the right of it:
 
 ```py
 # coding: pyxl

--- a/README.md
+++ b/README.md
@@ -154,27 +154,27 @@ Arguments to a UI module are passed as attributes to the UI module tag. Attribut
 ```py
 # coding: pyxl
 from pyxl.element import x_element
+from my.db.model import User
 
 class x_user_badge(x_element):
-    __attrs__ = {
-        'user': object,
-    }
-    def render(self):
+
+    def render(self, user: User):
         return (
             <div>
-                <img src="{self.user.profile_picture}" style="float: left; margin-right: 10px;"/>
+                <img src="{user.profile_picture}" style="float: left; margin-right: 10px;"/>
                 <div style="display: table-cell;">
-                    <div>{self.user.name}</div>
+                    <div>{user.name}</div>
                     {self.children()}
                 </div>
             </div>)
 ```
 
-This makes the tag `<user_badge>` available to us which accepts `user` as an attribute which is an object that contains the user's name and profile picture. Here is an example of this new UI module being used.
+This makes the tag `<user_badge>` available to us which accepts `user` as an attribute which is of `User` type and contains the user's name and profile picture. Here is an example of this new UI module being used.
 
 ```py
 # coding: pyxl
 from some_module import x_user_badge
+from my.db.model import User
 
 user = User.get(some_user_id)
 content = <div>Any arbitrary content...</div>
@@ -184,7 +184,7 @@ print <user_badge user="{user}">{content}</user_badge>
 Some things to note about UI modules.
 
 * Modules names must begin with `x_` and be an instance of `x_element`
-* Modules must specify the attributes they accept via the `__attrs__` class variable. This is a dictionary where the key is the attribute name, and the value is the attribute type. Passing an attribute that is not listed in `__attrs__` will result in an error. The only exceptions are attributes accepted by all pyxl elements i.e. id, class, style, onclick, title and anything prefixed with "data-" or "aria-"
+* There are two ways to specify attributes to UI Modules. You can either use python3 function annotations to `render()`, or use the `__attrs__` class variable. Both consists of keys and values in their own way. The key is the attribute name, and the value is the attribute type. Passing an attribute that is not listed in `__attrs__` or `render()` signature will result in an error. The only exceptions are attributes accepted by all pyxl elements i.e. id, class, style, onclick, title and anything prefixed with "data-" or "aria-".
 * Providing a `class` attribute for a UI module element will automatically append the class string to the underlying HTML element the UI module renders. This is useful when you want to style UI modules differently based on where it is being rendered.
 
 ### Fragments

--- a/pyxl/base.py
+++ b/pyxl/base.py
@@ -15,7 +15,7 @@ class PyxlException(Exception):
 
 class x_base_metaclass(type):
     def __init__(self, name, parents, attrs):
-        super(x_base_metaclass, self).__init__(name, parents, attrs)
+        super().__init__(name, parents, attrs)
         x_base_parents = [parent for parent in parents if hasattr(parent, '__attrs__')]
         parent_attrs = x_base_parents[0].__attrs__ if len(x_base_parents) else {}
         self_attrs = self.__dict__.get('__attrs__', {})
@@ -30,7 +30,7 @@ class x_base_metaclass(type):
         setattr(self, '__attrs__', combined_attrs)
         setattr(self, '__tag__', name[2:])
 
-class x_base(object, metaclass=x_base_metaclass):
+class x_base(metaclass=x_base_metaclass):
 
     __attrs__ = {
         # HTML attributes

--- a/pyxl/codec/html_tokenizer.py
+++ b/pyxl/codec/html_tokenizer.py
@@ -8,7 +8,7 @@ In the ATTRIBUTE_VALUE and BEFORE_ATTRIBUTE_VALUE states, python tokens are acce
 import sys
 from collections import OrderedDict
 
-class State(object):
+class State:
     DATA = 1
     # unused states: charrefs, RCDATA, script, RAWTEXT, PLAINTEXT
     TAG_OPEN = 7
@@ -45,7 +45,7 @@ class State(object):
                 return k
         assert False, "impossible state value %r!" % state_val
 
-class Tag(object):
+class Tag:
     def __init__(self):
         self.tag_name = None
         self.attrs = OrderedDict()
@@ -63,7 +63,7 @@ class BadCharError(Exception):
 class Unimplemented(Exception):
     pass
 
-class HTMLTokenizer(object):
+class HTMLTokenizer:
 
     def __init__(self):
         self.state = State.DATA

--- a/pyxl/codec/parser.py
+++ b/pyxl/codec/parser.py
@@ -150,10 +150,10 @@ class PyxlParser(HTMLTokenizer):
             else:
                 self.output.append(repr(part))
         else:
-            self.output.append('u"".join((')
+            self.output.append('"".join((')
             for part in attr_value:
                 if type(part) == list:
-                    self.output.append('unicode(')
+                    self.output.append('str(')
                     self.output.append(Untokenizer().untokenize(part))
                     self.output.append(')')
                 else:
@@ -261,9 +261,9 @@ class PyxlParser(HTMLTokenizer):
             return
 
         # XXX XXX mimics old pyxl, but this is gross and likely wrong. I'm pretty sure we actually
-        # want %r instead of this crazy quote substitution and u"%s".
+        # want %r instead of this crazy quote substitution and "%s".
         data = data.replace('"', '\\"')
-        self.output.append('html.rawhtml(u"%s"), ' % data)
+        self.output.append('html.rawhtml("%s"), ' % data)
 
         self.last_thing_was_python = False
         self.last_thing_was_close_if_tag = False

--- a/pyxl/codec/tokenizer.py
+++ b/pyxl/codec/tokenizer.py
@@ -18,7 +18,7 @@ def get_end_pos(start_pos, tvalue):
             col += 1
     return (row, col)
 
-class RewindableTokenStream(object):
+class RewindableTokenStream:
     """
     A token stream, with the ability to rewind and restart tokenization while maintaining correct
     token position information.

--- a/pyxl/element.py
+++ b/pyxl/element.py
@@ -32,7 +32,8 @@ class x_element(x_base):
     def _rendered_element(self):
         if self._element is None:
             self.prerender()
-            self._element = self.render()
+            attrs = {key.replace('-', '_'): getattr(self, key) for key in self._render_params}
+            self._element = self.render(**attrs)
             self.postrender(self._element)
         return self._element
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -2,6 +2,7 @@
 import unittest2
 from pyxl import html
 from pyxl.base import PyxlException, x_base
+from pyxl.element import x_element
 
 class PyxlTests(unittest2.TestCase):
 
@@ -85,6 +86,61 @@ class PyxlTests(unittest2.TestCase):
                 pass
 
         self.assertEqual(<baz />.value, None)
+
+    def test_render_args_are_added_to_pyxl_attributes(self):
+
+        class x_foo(x_element):
+            def render(self, value: int):
+                return <span>{value}</span>
+
+        self.assertEqual(<foo />.value, None)
+        self.assertEqual(<foo value="10" />.value, 10)
+        with self.assertRaises(PyxlException):
+            <foo value="boo" />.value
+
+        self.assertEqual(<foo value="11" />.to_string(), '<span>11</span>') 
+
+    def test_render_arg_supports_enum(self):
+
+        class x_foo(x_element):
+            def render(self, value: ['a', 'b']):
+                return <span>{value}</span>
+
+        self.assertEqual(<foo />.value, 'a')
+        self.assertEqual(<foo value="b" />.value, 'b')
+        with self.assertRaises(PyxlException):
+            <foo value="c" />.value
+
+    def test_render_arg_without_annotation(self):
+
+        class x_foo(x_element):
+            def render(self, value):
+                return <span>{value}</span>
+
+        self.assertEqual(<foo />.to_string(), '<span></span>')
+        self.assertEqual(<foo value="123" />.to_string(), '<span>123</span>')
+        self.assertEqual(<foo value="boo" />.to_string(), '<span>boo</span>')
+
+    def test_underscore_in_render_arg(self):
+
+        class x_foo(x_element):
+            def render(self, a_b_c: int):
+                return <span>{a_b_c}</span>
+
+        self.assertEqual(<foo a_b_c="1" />.to_string(), '<span>1</span>')
+
+    def test_attr_collision(self):
+
+        with self.assertRaises(PyxlException):
+
+            class x_foo(x_element):
+
+                __attrs__ = {
+                    'laughing': object
+                }
+
+                def render(self, laughing):
+                    pass
 
 if __name__ == '__main__':
     unittest2.main()


### PR DESCRIPTION
Hi,

I added an alternate syntax to pyxl3, which is now possible that it's in python3.
The `__attrs__` class variable is still supported, but I prefer a UI module to be defined this way:

``` python
def x_user_badge(x_element):
    def render(self, user: User):
        return <div>{user.name} - {user.age}</div>
```

It's cleaner that there is no need to write `self.` before arguments in `render()` body, and attributes are specified in the `render()` function's signature, using type annotations.
I tried to implement the feature the most strict way so unsupported syntax or defining an attribute in both places will result in an exception. Also has tests in test_basic.py.

enjoy!
-lez
