### PR TITLE
Fix the test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.cache
+__pycache__
+*egg-info/

--- a/README.md
+++ b/README.md
@@ -49,11 +49,9 @@ You should see the string `<html><body>Hello World!</body></html>` printed out. 
 After installing pyxl:
 
 ```sh
-python3 -m pip install unittest2
-python3 tests/test_basic.py
+pip install pytest
+pytest tests
 ```
-
-(This only runs the most basic of tests.  It seems the script to run all tests got lost.)
 
 ## How it works
 

--- a/pyxl/base.py
+++ b/pyxl/base.py
@@ -103,7 +103,7 @@ class x_base(object, metaclass=x_base_metaclass):
 
         # filter by class
         if selector[0] == '.':
-            select = lambda x: selector[1:] in x.get_class() 
+            select = lambda x: selector[1:] in x.get_class()
 
         # filter by id
         elif selector[0] == '#':
@@ -230,9 +230,6 @@ class x_base(object, metaclass=x_base_metaclass):
         raise NotImplementedError()
 
     def __str__(self):
-        return self.to_string()
-
-    def __unicode__(self):
         return self.to_string()
 
     @staticmethod

--- a/pyxl/codec/parser.py
+++ b/pyxl/codec/parser.py
@@ -153,7 +153,7 @@ class PyxlParser(HTMLTokenizer):
             self.output.append('u"".join((')
             for part in attr_value:
                 if type(part) == list:
-                    self.output.append('unicode(')
+                    self.output.append('str(')
                     self.output.append(Untokenizer().untokenize(part))
                     self.output.append(')')
                 else:

--- a/tests/error_cases/if_1.py.txt
+++ b/tests/error_cases/if_1.py.txt
@@ -1,7 +1,0 @@
-# coding: pyxl
-
-a = (<frag>
-         <if cond="{true}">foo</if>
-         this is incorrect!
-         <else>bar</else>
-     </frag>)

--- a/tests/error_cases/if_2.py.txt
+++ b/tests/error_cases/if_2.py.txt
@@ -1,7 +1,0 @@
-# coding: pyxl
-
-a = (<frag>
-         <if cond="{true}">foo</if>
-         <else>bar</else>
-         <else>baz</else>
-     </frag>)

--- a/tests/error_cases/if_3.py.txt
+++ b/tests/error_cases/if_3.py.txt
@@ -1,6 +1,0 @@
-# coding: pyxl
-
-a = (<frag>
-         <if cond="{true}">foo</if>
-         <else><else>bar</else></else>
-     </frag>)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,23 +1,31 @@
+# coding: pyxl
+import pytest
+
 from pyxl.codec.register import pyxl_decode
-from pyxl.codec.tokenizer import PyxlParseError
 from pyxl.codec.parser import ParseError
 
-import os
+def test_malformed_if():
+    with pytest.raises(ParseError):
+        pyxl_decode(b"""
+            <frag>
+                <if cond="{true}">foo</if>
+                this is incorrect!
+                <else>bar</else>
+            </frag>""")
 
-error_cases_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                                'error_cases')
+def test_multiple_else():
+    with pytest.raises(ParseError):
+        pyxl_decode(b"""
+            <frag>
+                <if cond="{true}">foo</if>
+                <else>bar</else>
+                <else>baz</else>
+             </frag>""")
 
-def _expect_failure(file_name):
-    path = os.path.join(error_cases_path, file_name)
-    try:
-        with open(path) as f:
-            print pyxl_decode(f.read())
-        assert False, "successfully decoded file %r" % file_name
-    except (PyxlParseError, ParseError):
-        pass
-
-def test_error_cases():
-    cases = os.listdir(error_cases_path)
-    for file_name in cases:
-        if file_name.endswith(".txt"):
-            yield (_expect_failure, file_name)
+def test_nested_else():
+    with pytest.raises(ParseError):
+        pyxl_decode(b"""
+            <frag>
+                <if cond="{true}">foo</if>
+                <else><else>bar</else></else>
+            </frag>""")

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -1,195 +1,189 @@
 #coding: pyxl
 import datetime
 
-from  unittest2 import TestCase
-from pyxl import html
-from pyxl import rss
+from pyxl import html, rss
 
-class RssTests(TestCase):
-    def test_decl(self):
-        decl = <rss.rss_decl_standalone />.to_string()
-        self.assertEqual(decl, u'<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>')
+def test_decl():
+    assert (str(<rss.rss_decl_standalone />)
+        == u'<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>')
 
-    def test_rss(self):
-        r = <rss.rss version="2.0" />.to_string()
-        self.assertEqual(r, u'<rss version="2.0"></rss>')
+def test_rss():
+    assert str(<rss.rss version="2.0" />) == u'<rss version="2.0"></rss>'
 
-    def test_channel(self):
-        c = (
+def test_channel():
+    assert str(
+        <rss.rss version="2.0">
+            <rss.channel />
+        </rss.rss>
+    ) == u'<rss version="2.0"><channel></channel></rss>'
+
+def test_channel_with_required_elements():
+    channel = (
+        <frag>
+            <rss.rss_decl_standalone />
             <rss.rss version="2.0">
-                <rss.channel />
+                <rss.channel>
+                    <rss.title>A Title</rss.title>
+                    <rss.link>https://www.dropbox.com</rss.link>
+                    <rss.description>A detailed description</rss.description>
+                </rss.channel>
             </rss.rss>
-        ).to_string()
+        </frag>
+    )
 
-        self.assertEqual(c, u'<rss version="2.0"><channel></channel></rss>')
-
-    def test_channel_with_required_elements(self):
-        channel = (
-            <frag>
-                <rss.rss_decl_standalone />
-                <rss.rss version="2.0">
-                    <rss.channel>
-                        <rss.title>A Title</rss.title>
-                        <rss.link>https://www.dropbox.com</rss.link>
-                        <rss.description>A detailed description</rss.description>
-                    </rss.channel>
-                </rss.rss>
-            </frag>
-        )
-
-        expected = '''
+    expected = '''
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <rss version="2.0">
-    <channel>
-        <title>A Title</title>
-        <link>https://www.dropbox.com</link>
-        <description>A detailed description</description>
-    </channel>
+<channel>
+    <title>A Title</title>
+    <link>https://www.dropbox.com</link>
+    <description>A detailed description</description>
+</channel>
 </rss>
 '''
-        expected = u''.join(l.strip() for l in expected.splitlines())
+    expected = u''.join(l.strip() for l in expected.splitlines())
 
-        self.assertEqual(channel.to_string(), expected)
+    assert str(channel) == expected
 
-    def test_channel_with_optional_elements(self):
-        channel = (
-            <frag>
-                <rss.rss_decl_standalone />
-                <rss.rss version="2.0">
-                    <rss.channel>
-                        <rss.title>A Title</rss.title>
-                        <rss.link>https://www.dropbox.com</rss.link>
-                        <rss.description>A detailed description</rss.description>
-                        <rss.ttl>60</rss.ttl>
-                        <rss.language>en-us</rss.language>
-                    </rss.channel>
-                </rss.rss>
-            </frag>
-        )
+def test_channel_with_optional_elements():
+    channel = (
+        <frag>
+            <rss.rss_decl_standalone />
+            <rss.rss version="2.0">
+                <rss.channel>
+                    <rss.title>A Title</rss.title>
+                    <rss.link>https://www.dropbox.com</rss.link>
+                    <rss.description>A detailed description</rss.description>
+                    <rss.ttl>60</rss.ttl>
+                    <rss.language>en-us</rss.language>
+                </rss.channel>
+            </rss.rss>
+        </frag>
+    )
 
-        expected = """
+    expected = """
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <rss version="2.0">
-    <channel>
-        <title>A Title</title>
-        <link>https://www.dropbox.com</link>
-        <description>A detailed description</description>
-        <ttl>60</ttl>
-        <language>en-us</language>
-    </channel>
+<channel>
+    <title>A Title</title>
+    <link>https://www.dropbox.com</link>
+    <description>A detailed description</description>
+    <ttl>60</ttl>
+    <language>en-us</language>
+</channel>
 </rss>
 """
 
-        expected = u''.join(l.strip() for l in expected.splitlines())
-        self.assertEqual(channel.to_string(), expected)
+    expected = u''.join(l.strip() for l in expected.splitlines())
+    assert str(channel) == expected
 
-    def test_item_with_common_elements(self):
-        item = (
-            <rss.item>
-                <rss.title>Item Title</rss.title>
-                <rss.description>
-                    {html.rawhtml('<![CDATA[ ')}
-                    This is a really interesting description
-                    {html.rawhtml(']]>')}
-                </rss.description>
-                <rss.link>https://www.dropbox.com/somewhere</rss.link>
-            </rss.item>
-        )
+def test_item_with_common_elements():
+    item = (
+        <rss.item>
+            <rss.title>Item Title</rss.title>
+            <rss.description>
+                {html.rawhtml('<![CDATA[ ')}
+                This is a really interesting description
+                {html.rawhtml(']]>')}
+            </rss.description>
+            <rss.link>https://www.dropbox.com/somewhere</rss.link>
+        </rss.item>
+    )
 
-        expected = """
+    expected = """
 <item>
-    <title>Item Title</title>
-    <description><![CDATA[  This is a really interesting description ]]></description>
-    <link>https://www.dropbox.com/somewhere</link>
+<title>Item Title</title>
+<description><![CDATA[  This is a really interesting description ]]></description>
+<link>https://www.dropbox.com/somewhere</link>
 </item>
 """
 
-        expected = u''.join(l.strip() for l in expected.splitlines())
-        self.assertEqual(item.to_string(), expected)
+    expected = u''.join(l.strip() for l in expected.splitlines())
+    assert str(item) == expected
 
-    def test_guid(self):
-        self.assertEqual(<rss.guid>foo</rss.guid>.to_string(), u'<guid>foo</guid>')
-        self.assertEqual(<rss.guid is-perma-link="{False}">foo</rss.guid>.to_string(), 
-                         u'<guid isPermaLink="false">foo</guid>')
-        self.assertEqual(<rss.guid is-perma-link="{True}">foo</rss.guid>.to_string(),
-                         u'<guid isPermaLink="true">foo</guid>')
+def test_guid():
+    assert str(<rss.guid>foo</rss.guid>) == u'<guid>foo</guid>'
+    assert (str(<rss.guid is-perma-link="{False}">foo</rss.guid>)
+            == u'<guid isPermaLink="false">foo</guid>')
+    assert (str(<rss.guid is-perma-link="{True}">foo</rss.guid>)
+            == u'<guid isPermaLink="true">foo</guid>')
 
-    def test_date_elements(self):
-        dt = datetime.datetime(2013, 12, 17, 23, 54, 14)
-        self.assertEqual(<rss.pubDate date="{dt}" />.to_string(),
-                         u'<pubDate>Tue, 17 Dec 2013 23:54:14 GMT</pubDate>')
-        self.assertEqual(<rss.lastBuildDate date="{dt}" />.to_string(),
-                         u'<lastBuildDate>Tue, 17 Dec 2013 23:54:14 GMT</lastBuildDate>')
+def test_date_elements():
+    dt = datetime.datetime(2013, 12, 17, 23, 54, 14)
+    assert (str(<rss.pubDate date="{dt}" />)
+            == u'<pubDate>Tue, 17 Dec 2013 23:54:14 GMT</pubDate>')
+    assert (str(<rss.lastBuildDate date="{dt}" />)
+            == u'<lastBuildDate>Tue, 17 Dec 2013 23:54:14 GMT</lastBuildDate>')
 
-    def test_rss_document(self):
-        dt = datetime.datetime(2013, 12, 17, 23, 54, 14)
-        dt2 = datetime.datetime(2013, 12, 18, 11, 54, 14)
-        doc = (
-            <frag>
-                <rss.rss_decl_standalone />
-                <rss.rss version="2.0">
-                    <rss.channel>
-                        <rss.title>A Title</rss.title>
-                        <rss.link>https://www.dropbox.com</rss.link>
-                        <rss.description>A detailed description</rss.description>
-                        <rss.ttl>60</rss.ttl>
-                        <rss.language>en-us</rss.language>
-                        <rss.lastBuildDate date="{dt}" />
-                        <rss.item>
-                            <rss.title>Item Title</rss.title>
-                            <rss.description>
-                                {html.rawhtml('<![CDATA[ ')}
-                                This is a really interesting description
-                                {html.rawhtml(']]>')}
-                            </rss.description>
-                            <rss.link>https://www.dropbox.com/somewhere</rss.link>
-                            <rss.pubDate date="{dt}" />
-                            <rss.guid is-perma-link="{False}">123456789</rss.guid>
-                        </rss.item>
-                        <rss.item>
-                            <rss.title>Another Item</rss.title>
-                            <rss.description>
-                                {html.rawhtml('<![CDATA[ ')}
-                                This is another really interesting description
-                                {html.rawhtml(']]>')}
-                            </rss.description>
-                            <rss.link>https://www.dropbox.com/nowhere</rss.link>
-                            <rss.pubDate date="{dt2}" />
-                            <rss.guid is-perma-link="{False}">ABCDEFGHIJ</rss.guid>
-                        </rss.item>
-                    </rss.channel>
-                </rss.rss>
-            </frag>
-        )
+def test_rss_document():
+    dt = datetime.datetime(2013, 12, 17, 23, 54, 14)
+    dt2 = datetime.datetime(2013, 12, 18, 11, 54, 14)
+    doc = (
+        <frag>
+            <rss.rss_decl_standalone />
+            <rss.rss version="2.0">
+                <rss.channel>
+                    <rss.title>A Title</rss.title>
+                    <rss.link>https://www.dropbox.com</rss.link>
+                    <rss.description>A detailed description</rss.description>
+                    <rss.ttl>60</rss.ttl>
+                    <rss.language>en-us</rss.language>
+                    <rss.lastBuildDate date="{dt}" />
+                    <rss.item>
+                        <rss.title>Item Title</rss.title>
+                        <rss.description>
+                            {html.rawhtml('<![CDATA[ ')}
+                            This is a really interesting description
+                            {html.rawhtml(']]>')}
+                        </rss.description>
+                        <rss.link>https://www.dropbox.com/somewhere</rss.link>
+                        <rss.pubDate date="{dt}" />
+                        <rss.guid is-perma-link="{False}">123456789</rss.guid>
+                    </rss.item>
+                    <rss.item>
+                        <rss.title>Another Item</rss.title>
+                        <rss.description>
+                            {html.rawhtml('<![CDATA[ ')}
+                            This is another really interesting description
+                            {html.rawhtml(']]>')}
+                        </rss.description>
+                        <rss.link>https://www.dropbox.com/nowhere</rss.link>
+                        <rss.pubDate date="{dt2}" />
+                        <rss.guid is-perma-link="{False}">ABCDEFGHIJ</rss.guid>
+                    </rss.item>
+                </rss.channel>
+            </rss.rss>
+        </frag>
+    )
 
-        expected = """
+    expected = """
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <rss version="2.0">
-    <channel>
-        <title>A Title</title>
-        <link>https://www.dropbox.com</link>
-        <description>A detailed description</description>
-        <ttl>60</ttl>
-        <language>en-us</language>
-        <lastBuildDate>Tue, 17 Dec 2013 23:54:14 GMT</lastBuildDate>
-        <item>
-            <title>Item Title</title>
-            <description><![CDATA[  This is a really interesting description ]]></description>
-            <link>https://www.dropbox.com/somewhere</link>
-            <pubDate>Tue, 17 Dec 2013 23:54:14 GMT</pubDate>
-            <guid isPermaLink="false">123456789</guid>
-        </item>
-        <item>
-            <title>Another Item</title>
-            <description><![CDATA[  This is another really interesting description ]]></description>
-            <link>https://www.dropbox.com/nowhere</link>
-            <pubDate>Wed, 18 Dec 2013 11:54:14 GMT</pubDate>
-            <guid isPermaLink="false">ABCDEFGHIJ</guid>
-        </item>
-    </channel>
+<channel>
+    <title>A Title</title>
+    <link>https://www.dropbox.com</link>
+    <description>A detailed description</description>
+    <ttl>60</ttl>
+    <language>en-us</language>
+    <lastBuildDate>Tue, 17 Dec 2013 23:54:14 GMT</lastBuildDate>
+    <item>
+        <title>Item Title</title>
+        <description><![CDATA[  This is a really interesting description ]]></description>
+        <link>https://www.dropbox.com/somewhere</link>
+        <pubDate>Tue, 17 Dec 2013 23:54:14 GMT</pubDate>
+        <guid isPermaLink="false">123456789</guid>
+    </item>
+    <item>
+        <title>Another Item</title>
+        <description><![CDATA[  This is another really interesting description ]]></description>
+        <link>https://www.dropbox.com/nowhere</link>
+        <pubDate>Wed, 18 Dec 2013 11:54:14 GMT</pubDate>
+        <guid isPermaLink="false">ABCDEFGHIJ</guid>
+    </item>
+</channel>
 </rss>
 """
 
-        expected = ''.join(l.strip() for l in expected.splitlines())
+    expected = ''.join(l.strip() for l in expected.splitlines())
 
-        self.assertEqual(doc.to_string(), expected)
+    assert str(doc) ==  expected


### PR DESCRIPTION
As noted in the current README, there is no documented way of running the full test suite. In fact there's never been a script for running the full suite: what happened is that the original script pyxl_tests.py was renamed and then more tests were added but without any instructions.

This PR aims to fix that, plus a few other problems:
1. Tests are written in two different styles: the new tests are written using plain assert. Old tests have been cleaned up to be consistent with that.
2. Some of the tests were broken in Python 3 - PyxlParser has been fixed and the tests now pass.
3. Update README with documentation for running the full test suite.

META:

This PR is being made from an organisation called `pyxl3` that I created specifically to make these changes. I had to do this because I already made a similar PR to the original `pyxl` [link](https://github.com/dropbox/pyxl/pull/9) and GitHub wouldn't let me then fork your fork whilst having a fork of the original `pyxl` at the same time (ugh).

However, this might present an opportunity to improve the contributor experience for this project. @gvanrossum would you be happy if the repo at pyxl3/pyxl3 becomes the 'official' Python 3 port of `pyxl3`? You can, of course, be a full admin member of this organisation. I would then request with GitHub to turn the repo from a fork to a standalone repo.

The motivation on my side is that I would like to give this project some 'love'. Here are some ways I'd like to work on improving it:
- [ ] Enable issues (at the moment we don't have an issue tracker enabled).
- [ ] Add test coverage, build status badges etc.
- [ ] Address any gaps in test coverage
- [ ] Put the whole project through a linter (I notice some PEP8 violations).
- [ ] Speed / test benchmarks
- [ ] Incorporate optimisations from the original `pyxl` project, eg [link](https://github.com/dropbox/pyxl/pull/8)
- [ ] Use tox to run tests over multiple versions of Python 3.
- [ ] Rework the documentation: and host the docs on pyxl3.github.io.
- [ ] Setup on PyPI so users can just `pip install pyxl3` instead of cloning from GitHub.
- [ ] And, maybe, backport compatibility to Python 2.
