### PR TITLE
Reduce startup overhead of pyxl being installed

### DIFF
--- a/pyxl.pth
+++ b/pyxl.pth
@@ -1,1 +1,1 @@
-import pyxl.codec.register
+import pyxl.codec.fast_register

--- a/pyxl/codec/fast_register.py
+++ b/pyxl/codec/fast_register.py
@@ -1,0 +1,8 @@
+import codecs
+
+def search_function(encoding):
+    if encoding != 'pyxl': return None
+    import pyxl.codec.register
+    return pyxl.codec.register.search_function(encoding)
+
+codecs.register(search_function)

--- a/pyxl/codec/fast_register.py
+++ b/pyxl/codec/fast_register.py
@@ -1,7 +1,8 @@
 import codecs
 
 def search_function(encoding):
-    if encoding != 'pyxl': return None
+    if encoding != 'pyxl':
+        return None
     import pyxl.codec.register
     return pyxl.codec.register.search_function(encoding)
 

--- a/pyxl/codec/register.py
+++ b/pyxl/codec/register.py
@@ -53,7 +53,9 @@ def search_function(encoding):
         streamreader = PyxlStreamReader,
         streamwriter = utf8.streamwriter)
 
-codecs.register(search_function)
+
+# This import will do the actual registration with codecs
+import pyxl.codec.fast_register
 
 _USAGE = """\
 Wraps a python command to allow it to recognize pyxl-coded files with


### PR DESCRIPTION
pyxl needs to register itself as a codec on python startup, but it
doesn't need to actually import any of the pyxl machinery until it
needs to decode something.

The mild gymnastics performed (changing the module to import on
startup to `fast_register` and then importing that from the original
`register`) are to keep the diff size small while not breaking
`register`'s functionality as a script.

This shaves about 60ms off `python3 -c ''` with pyxl installed on my
laptop (from 100ms to 40ms!), which is 10ms more than a slightly
simpler change that just moves the `pyxl.codec.tokenizer` import into
`pyxl_transform`.