### PR TITLE
Improve the generated code for <if> conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+build/
+__pycache__
+*.py[cod]
+*~
+@*
+/build
+/env*/
+*.iml
+/out/
+.venv*/
+.mypy_cache/
+.cache
+.dmypy.json
+
+# Packages
+*.egg
+*.egg-info
+*.eggs
+
+# IDEs
+.idea
+*.swp
+.vscode
+
+# Operating Systems
+.DS_Store
+
+# Coverage Files
+htmlcov
+.coverage*
+
+# pytest cache
+.pytest_cache/
+
+# virtualenv
+.Python
+bin/
+lib/
+include/
+
+.tox
+pip-wheel-metadata

--- a/pyxl/codec/parser.py
+++ b/pyxl/codec/parser.py
@@ -28,14 +28,12 @@ class PyxlParser(HTMLTokenizer):
         self.last_thing_was_close_if_tag = False
 
     def delete_last_comma(self):
-        i = len(self.output) - 1
-        while i >= 0:
+        for i in reversed(range(len(self.output))):
             stripped = self.output[i].rstrip()
             if stripped and not stripped[0] == '#':
                 assert stripped[-1] == ',', (self.output, stripped, i)
                 self.output[i] = self.output[i][:len(stripped)-1] + self.output[i][len(stripped):]
                 return
-            i -= 1
         assert False, "couldn't find a comma"
 
     def handle_close_if(self):

--- a/pyxl/codec/parser.py
+++ b/pyxl/codec/parser.py
@@ -27,6 +27,27 @@ class PyxlParser(HTMLTokenizer):
         self.last_thing_was_python = False
         self.last_thing_was_close_if_tag = False
 
+    def delete_last_comma(self):
+        i = len(self.output) - 1
+        while i >= 0:
+            stripped = self.output[i].rstrip()
+            if stripped and not stripped[0] == '#':
+                assert stripped[-1] == ',', (self.output, stripped, i)
+                self.output[i] = self.output[i][:len(stripped)-1] + self.output[i][len(stripped):]
+                return
+            i -= 1
+        assert False, "couldn't find a comma"
+
+    def handle_close_if(self):
+        """Clean up after an unpaired if statement.
+
+        Should be called at the beginning of any construct other than an else.
+        """
+        if self.last_thing_was_close_if_tag:
+            self.delete_last_comma()
+            self.output.append(' else None, ')
+            self.last_thing_was_close_if_tag = False
+
     def feed(self, token):
         ttype, tvalue, tstart, tend, tline = token
 
@@ -57,6 +78,8 @@ class PyxlParser(HTMLTokenizer):
             self.end = tend
 
     def feed_python(self, tokens):
+        self.handle_close_if()
+
         ttype, tvalue, tstart, tend, tline = tokens[0]
         assert tstart[0] >= self.end[0], "row went backwards"
         if tstart[0] > self.end[0]:
@@ -180,16 +203,16 @@ class PyxlParser(HTMLTokenizer):
         return data
 
     def handle_starttag(self, tag, attrs, call=True):
-        self.open_tags.append({'tag':tag, 'row': self.end[0]})
+        self.open_tags.append({'tag':tag, 'row': self.end[0], 'attrs': attrs})
         if tag == 'if':
+            self.handle_close_if()
+
             if len(attrs) != 1:
                 raise ParseError("if tag only takes one attr called 'cond'", self.end)
             if 'cond' not in attrs:
                 raise ParseError("if tag must contain the 'cond' attr", self.end)
 
-            self.output.append('html._push_condition(bool(')
-            self._handle_attr_value(attrs['cond'])
-            self.output.append(')) and html.x_frag()(')
+            self.output.append('html.x_frag()(')
             self.last_thing_was_python = False
             self.last_thing_was_close_if_tag = False
             return
@@ -199,10 +222,13 @@ class PyxlParser(HTMLTokenizer):
             if not self.last_thing_was_close_if_tag:
                 raise ParseError("<else> tag must come right after </if>", self.end)
 
-            self.output.append('(not html._last_if_condition) and html.x_frag()(')
+            self.delete_last_comma()
+            self.output.append('else html.x_frag()(')
             self.last_thing_was_python = False
             self.last_thing_was_close_if_tag = False
             return
+
+        self.handle_close_if()
 
         module, dot, identifier = tag.rpartition('.')
         identifier = 'x_%s' % identifier
@@ -229,6 +255,8 @@ class PyxlParser(HTMLTokenizer):
         self.last_thing_was_close_if_tag = False
 
     def handle_endtag(self, tag_name, call=True):
+        self.handle_close_if()
+
         if call:
             # finish call to __call__
             self.output.append(")")
@@ -241,7 +269,8 @@ class PyxlParser(HTMLTokenizer):
                              (open_tag['tag'], open_tag['row'], tag_name, self.end[0]))
 
         if open_tag['tag'] == 'if':
-            self.output.append(',html._leave_if()')
+            self.output.append(' if ')
+            self._handle_attr_value(open_tag['attrs']['cond'])
             self.last_thing_was_close_if_tag = True
         else:
             self.last_thing_was_close_if_tag = False
@@ -259,6 +288,8 @@ class PyxlParser(HTMLTokenizer):
                 data, self.last_thing_was_python, self.next_thing_is_python)
         if not data:
             return
+
+        self.handle_close_if()
 
         # XXX XXX mimics old pyxl, but this is gross and likely wrong. I'm pretty sure we actually
         # want %r instead of this crazy quote substitution and u"%s".

--- a/pyxl/html.py
+++ b/pyxl/html.py
@@ -6,18 +6,6 @@ from pyxl.base import x_base
 # for backwards compatibility.
 from pyxl.browser_hacks import x_cond_comment
 
-_if_condition_stack = []
-_last_if_condition = None
-
-def _push_condition(cond):
-    _if_condition_stack.append(cond)
-    return cond
-
-def _leave_if():
-    global _last_if_condition
-    _last_if_condition = _if_condition_stack.pop()
-    return []
-
 class x_html_element(x_base):
     def _to_list(self, l):
         l.extend(('<', self.__tag__))

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -46,6 +46,76 @@ class PyxlTests(unittest2.TestCase):
             <form_error name="foo" />.to_string(),
             '<form:error name="foo" />')
 
+
+    def test_if(self):
+        self.assertEqual(
+            <div><if cond="{True}"><div /></if></div>.to_string(),
+            '<div><div></div></div>')
+        self.assertEqual(
+            <div><if cond="{False}"><div /></if></div>.to_string(),
+            '<div></div>')
+
+    def test_if_else(self):
+        lol = [<span></span>, <span></span>]
+
+        self.assertEqual(
+            <div>
+            <if cond="{True}">
+                <div />
+            </if>
+            # welp
+            lol
+            </div>.to_string(),
+            '<div><div></div>lol</div>')
+        self.assertEqual(
+            <div>
+            <if cond="{True}"></if>
+            # welp
+            <else>lol</else>
+            </div>.to_string(),
+            '<div></div>')
+        self.assertEqual(
+            <div>
+            <if cond="{True}"></if>
+            </div>.to_string(),
+            '<div></div>')
+        self.assertEqual(
+            <div>
+            <if cond="{False}"><div /></if>
+            <if cond="{True}"><div /></if>
+            {lol}
+            </div>.to_string(),
+            '<div><div></div><span></span><span></span></div>')
+        self.assertEqual(
+            <div>
+            <if cond="{True}"><div /></if>
+            <else>test</else>
+            </div>.to_string(),
+            '<div><div></div></div>')
+        self.assertEqual(
+            <div>
+            <if cond="{True}"><div /><div /></if>
+            <else><span></span></else>
+            </div>.to_string(),
+            '<div><div></div><div></div></div>')
+        self.assertEqual(
+            <div>
+            <if cond="{False}"><div /></if>
+            <else><span></span></else>
+            </div>.to_string(),
+            '<div><span></span></div>')
+
+        self.assertEqual(
+            <div>
+            <if cond="{True}">
+                {lol}
+                <if cond="{False}">
+                whatever
+                </if>
+            </if>
+            </div>.to_string(),
+            '<div><span></span><span></span></div>')
+
     def test_enum_attrs(self):
         class x_foo(x_base):
             __attrs__ = {


### PR DESCRIPTION
Currently pyxl uses a global stack (!) of results from if conditions
to determine whether to execute else branches.

Instead, use if-else to do it in a more natural manner.

Unfortunately, because the parser is structured in a very streaming
manner, we don't know whether an if has an else block until after
fully processing it, so we do some tasteless rewriting of the output
to handle this.

The main purpose of this is to produce better looking code so that we
can compile everything to the target python and throw away the pyxl
codec, but I suppose it also fixes a thread-safety bug and probably
makes things faster too.