### PR TITLE
Revert "Eliminate the double call when there are children but no attributes"

### DIFF
--- a/pyxl/base.py
+++ b/pyxl/base.py
@@ -79,18 +79,12 @@ class x_base(object, metaclass=x_base_metaclass):
         'onunload': str,
         }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         self.__attributes__ = {}
         self.__children__ = []
 
-        if args and kwargs:
-            raise PyxlException('Element constructor can take children or attributes, not both')
-
-        if args:
-            self.append_children(args)
-        else:
-            for name, value in kwargs.items():
-                self.set_attr(x_base._fix_attribute_name(name), value)
+        for name, value in kwargs.items():
+            self.set_attr(x_base._fix_attribute_name(name), value)
 
     def __call__(self, *children):
         self.append_children(children)

--- a/pyxl/codec/parser.py
+++ b/pyxl/codec/parser.py
@@ -224,7 +224,7 @@ class PyxlParser(HTMLTokenizer):
                 raise ParseError("if tag must contain the 'cond' attr", self.end)
 
             self.open_tags[-1]['open'] = len(self.output)  # track x_frag pos so it can be deleted
-            self.output.append('html.x_frag(')
+            self.output.append('html.x_frag()(')
             self.last_thing_was_python = False
             self.last_thing_was_close_if_tag = False
             return
@@ -236,8 +236,8 @@ class PyxlParser(HTMLTokenizer):
 
             self.delete_last_comma()
             self.output.append('else ')
-            self.open_tags[-1]['open'] = len(self.output)
-            self.output.append('html.x_frag(')  # track x_frag pos so it can be deleted
+            self.open_tags[-1]['open'] = len(self.output)  # track x_frag pos so it can be deleted
+            self.output.append('html.x_frag()(')
             self.last_thing_was_python = False
             self.last_thing_was_close_if_tag = False
             return
@@ -250,10 +250,7 @@ class PyxlParser(HTMLTokenizer):
 
         if hasattr(html, x_tag):
             self.output.append('html.')
-        self.output.append(x_tag)
-
-        if attrs or not call:
-            self.output.append('(')
+        self.output.append('%s(' % x_tag)
 
         first_attr = True
         for attr_name, attr_value in attrs.items():
@@ -264,9 +261,7 @@ class PyxlParser(HTMLTokenizer):
             self.output.append('=')
             self._handle_attr_value(attr_value)
 
-        if attrs or not call:
-            self.output.append(')')
-
+        self.output.append(')')
         if call:
             # start call to __call__
             self.output.append('(')


### PR DESCRIPTION
We decided that this was too risky because of components that override
`__init__`.

This reverts commit 96e9fc6.