### PR TITLE
Emit 'str' instead of 'unicode' when joining together attr values

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ With that, you can start using HTML in your python file.
 
 ### Inline Python Expressions
 
-Anything wrapped with {}'s is evaluated as a python expression. Please note that attribute values must be wrapped inside quotes, regardless of whether it contains a python expression or not. When used in attribute values, the python expression must evaluate to something that can be cast to unicode. When used inside a tag, the expression can evaluate to anything that can be cast to unicode, an HTML tag, or a list containing those two types. This is demonstrated in the example below:
+Anything wrapped with {}'s is evaluated as a python expression. Please note that attribute values must be wrapped inside quotes, regardless of whether it contains a python expression or not. When used in attribute values, the python expression must evaluate to something that can be cast to str. When used inside a tag, the expression can evaluate to anything that can be cast to str, an HTML tag, or a list containing those two types. This is demonstrated in the example below:
 
 ```py
 image_name = "bolton.png"
@@ -147,7 +147,7 @@ UI Modules are especially useful for creating re-usable building blocks in your 
 
 Creating UI modules in Pyxl simply means creating a class that inherits from [`x_element`](https://github.com/dropboxe/pyxl/blob/master/pyxl/pyxl/element.py) and implements the `render()` method. Modules must be prefixed with `x_`. This is an arbitrary requirement, but is useful in separating out pyxl modules from other things.
 
-Arguments to a UI module are passed as attributes to the UI module tag. Attribute values for these tags need not evaluate to samething that can be cast to unicode, ONLY if the attribute value is a single python expression i.e. the only thing inside the quotes is a {} wrapped python expression. This allows one to pass in any type to a UI module. To demonstrate, a useful UI module is a user badge, which displays a user profile picture with the user's name and some arbitrary content to the right of it:
+Arguments to a UI module are passed as attributes to the UI module tag. Attribute values for these tags need not evaluate to samething that can be cast to str, ONLY if the attribute value is a single python expression i.e. the only thing inside the quotes is a {} wrapped python expression. This allows one to pass in any type to a UI module. To demonstrate, a useful UI module is a user badge, which displays a user profile picture with the user's name and some arbitrary content to the right of it:
 
 ```py
 # coding: pyxl

--- a/pyxl/codec/parser.py
+++ b/pyxl/codec/parser.py
@@ -194,7 +194,7 @@ class PyxlParser(HTMLTokenizer):
             self.output.append('u"".join((')
             for part in attr_value:
                 if type(part) == list:
-                    self.output.append('unicode(')
+                    self.output.append('str(')
                     self.output.append(Untokenizer().untokenize(part))
                     self.output.append(')')
                 else:

--- a/tests/test_curlies_in_attrs_2.py
+++ b/tests/test_curlies_in_attrs_2.py
@@ -1,6 +1,5 @@
 # coding: pyxl
 from pyxl import html
-unicode = str  # dumb testing hack
 
 def test():
     assert str(<frag><img src="barbaz{'foo'}" /></frag>) == """<img src="barbazfoo" />"""

--- a/tests/test_whitespace_10.py
+++ b/tests/test_whitespace_10.py
@@ -1,6 +1,5 @@
 # coding: pyxl
 from pyxl import html
-unicode = str  # dumb testing hack
 
 def test():
     assert str(<div class="{'foo'} {'bar'}"></div>) == '<div class="foo bar"></div>'


### PR DESCRIPTION
To the extent we care about this code actually working in Python 3,
this is obviously an improvement. We don't /really/ care about that,
so this is really more about making the typechecking work under Python 3.

(Using `str` on 2 is incorrect from an actual running code
perspective but should basically be fine from a mypy typechecking
perspective. We could use `typing.Text` or `six.string_types` but that
adds a dependency and would require an import in files that use it.)