### PR TITLE
Parenthesize generator expressions

### DIFF
--- a/tests/test_comprehension.py
+++ b/tests/test_comprehension.py
@@ -1,0 +1,15 @@
+# coding: pyxl
+
+from pyxl import html
+
+# Only testing that this produces valid code
+def f(self):
+   x = <ul class="something">{x for x in range(10)}</ul>
+   y = <ul class="something">{x
+                           for x in range(10)}</ul>
+
+   z = <ul class="something">{(x)for(x) in range(10)}</ul>
+
+   # These *shouldn't* get parens
+   w = <ul class="something">{(x for x in range(10))}</ul>
+   w = <ul class="something">{[x for x in range(10)]}</ul>


### PR DESCRIPTION
This fixes issues with commas after a generator expression as a sole
argument being disallowed in Python 3.7 but allowed in earlier
versions.

We parenthesize only generator expressions since we're trying to keep
the output looking good so it can be used to remove pyxl if needed...