### PR TITLE
Include trailing comments in the literally quoted pyxl block

### DIFF
--- a/pyxl/codec/pytokenize.py
+++ b/pyxl/codec/pytokenize.py
@@ -259,6 +259,8 @@ class Untokenizer:
         tok_type, token, start, end, line = t
         if (self.prev_row is None):
             self.prev_row, self.prev_col = start
+        if tok_type in (NEWLINE, NL):
+            self.prev_col = end[1]
         self.add_whitespace(start)
         self.tokens.append(token)
         self.prev_row, self.prev_col = end

--- a/pyxl/codec/tokenizer.py
+++ b/pyxl/codec/tokenizer.py
@@ -308,6 +308,19 @@ def get_pyxl_token(start_token, tokens, invertible):
 
     pyxl_parser_start = Pos(*pyxl_parser.start)
     if invertible:
+        # We want to try to a trailing comment after a pyxl close in
+        # the pyxl block itself to prevent black from migrating it.
+        # (which matters a lot if it is a type: ignore.)
+        try:
+            peek = fix_token(next(tokens))
+        except StopIteration:
+            pass
+        else:
+            if peek.ttype == tokenize.COMMENT:
+                pyxl_tokens.append(peek)
+            else:
+                tokens.unshift(peek)
+
         output = "html.PYXL('''{}''', {}, {}, {}{}{})".format(
             untokenize(pyxl_tokens).replace('\\', '\\\\').replace("'", "\\'"),
             # Include the real compiled pyxl so that tools can see all the gritty details

--- a/pyxl/codec/tokenizer.py
+++ b/pyxl/codec/tokenizer.py
@@ -308,7 +308,7 @@ def get_pyxl_token(start_token, tokens, invertible):
 
     pyxl_parser_start = Pos(*pyxl_parser.start)
     if invertible:
-        # We want to try to a trailing comment after a pyxl close in
+        # We want to include a trailing comment after a pyxl close in
         # the pyxl block itself to prevent black from migrating it.
         # (which matters a lot if it is a type: ignore.)
         try:

--- a/tests/test_black_input.py
+++ b/tests/test_black_input.py
@@ -79,3 +79,10 @@ class B:
 
             ))}
         </div>)
+
+    def bar(self):
+        return (
+            <something
+                class="foo"
+            />  # type: ignore[arg-type]
+        )

--- a/tests/test_black_input.py.exp
+++ b/tests/test_black_input.py.exp
@@ -125,3 +125,10 @@ class B:
                 }
             </div>
         )
+
+    def bar(self):
+        return (
+            <something
+                class="foo"
+            />  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
This keeps the black+pyxl combo from shifting type: ignores off the
line.

@jhance