### PR TITLE
Allow overriding what function we use to convert to str

### DIFF
--- a/pyxl/codec/parser.py
+++ b/pyxl/codec/parser.py
@@ -18,7 +18,7 @@ class ParseError(Exception):
             super(ParseError, self).__init__(message)
 
 class PyxlParser(HTMLTokenizer):
-    def __init__(self, row, col):
+    def __init__(self, row, col, str_function):
         super(PyxlParser, self).__init__()
         self.start = self.end = (row, col)
         self.output = []
@@ -27,6 +27,7 @@ class PyxlParser(HTMLTokenizer):
         self.next_thing_is_python = False
         self.last_thing_was_python = False
         self.last_thing_was_close_if_tag = False
+        self.str_function = str_function
 
     def delete_last_comma(self):
         for i in reversed(range(len(self.output))):
@@ -199,7 +200,7 @@ class PyxlParser(HTMLTokenizer):
             self.output.append('u"".join((')
             for part in attr_value:
                 if type(part) == list:
-                    self.output.append('str(')
+                    self.output.append('{}('.format(self.str_function))
                     self.output.append(Untokenizer().untokenize(part))
                     self.output.append(')')
                 else:

--- a/pyxl/codec/transform.py
+++ b/pyxl/codec/transform.py
@@ -7,9 +7,9 @@ from pyxl.codec.tokenizer import (
     PyxlUnfinished,
 )
 
-def pyxl_transform(stream, invertible=False):
+def pyxl_transform(stream, invertible=False, str_function='str'):
     try:
-        output = pyxl_untokenize(pyxl_tokenize(stream.readline, invertible))
+        output = pyxl_untokenize(pyxl_tokenize(stream.readline, invertible, str_function))
     except Exception as ex:
         print(ex)
         traceback.print_exc()
@@ -31,9 +31,9 @@ def pyxl_invert(stream):
     return output
 
 
-def pyxl_transform_string(input, invertible=False):
+def pyxl_transform_string(input, invertible=False, str_function='str'):
     stream = io.StringIO(input)
-    return pyxl_transform(stream, invertible)
+    return pyxl_transform(stream, invertible, str_function)
 
 
 def pyxl_invert_string(input):


### PR DESCRIPTION
Always calling `str` causes trouble in the case where we are using
the codec to depyxlize python 2 code.